### PR TITLE
build(cmake): fetch the BLAKE3 dependency via FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.18)
 
 project(search VERSION 0.3.0)
 
@@ -25,17 +25,25 @@ function(fetch_if_not_exists name git_repo git_tag)
   endif()
 endfunction()
 
-enable_testing()
-
 fetch_if_not_exists(minizip
   https://github.com/nmoinvaz/minizip.git
   4.0.7
 )
 
-if(NOT EXISTS ${CMAKE_SOURCE_DIR}/vendor/blake3)
-  message(FATAL_ERROR "vendor/blake3 not found; please fetch BLAKE3 sources.")
+if(EXISTS ${CMAKE_SOURCE_DIR}/vendor/blake3/c)
+  message(STATUS "Using local BLAKE3 checkout from vendor/blake3")
+  add_subdirectory(${CMAKE_SOURCE_DIR}/vendor/blake3/c ${CMAKE_BINARY_DIR}/blake3-build EXCLUDE_FROM_ALL)
+else()
+  FetchContent_Declare(
+    blake3
+    GIT_REPOSITORY https://github.com/BLAKE3-team/BLAKE3.git
+    GIT_TAG        1.8.5
+    GIT_SHALLOW    TRUE
+    GIT_PROGRESS   TRUE
+    SOURCE_SUBDIR  c
+  )
+  FetchContent_MakeAvailable(blake3)
 endif()
-add_subdirectory(${CMAKE_SOURCE_DIR}/vendor/blake3/c ${CMAKE_BINARY_DIR}/blake3-build EXCLUDE_FROM_ALL)
 
 FetchContent_Declare(
   googletest
@@ -55,7 +63,6 @@ target_include_directories(search_core PUBLIC
   ${CMAKE_SOURCE_DIR}/vendor/minizip
   ${CMAKE_SOURCE_DIR}/vendor/minizip/zlib
   ${CMAKE_SOURCE_DIR}/vendor/minizip/third_party/zlib
-  ${CMAKE_SOURCE_DIR}/vendor/tbb/include
 )
 
 target_precompile_headers(search_core PUBLIC include/rockyou/pch.h)
@@ -109,30 +116,6 @@ if(WIN32)
 endif()
 
 add_test(NAME search_tests COMMAND search_tests)
-
-add_executable(search_cli_tests
-  tests/cli/test_quiet_mode.cc
-  tests/cli/test_json_output.cc
-  tests/cli/test_perf_flags.cc
-  tests/cli/test_integrity.cc
-  tests/cli/test_corrupt_entry.cc
-  tests/cli/test_interactive_loop.cc
-  tests/cli/test_interactive_validation.cc
-)
-
-set(SEARCH_BINARY_PATH_VALUE "${CMAKE_BINARY_DIR}/bin/search")
-if(WIN32)
-  set(SEARCH_BINARY_PATH_VALUE "${CMAKE_BINARY_DIR}/bin/search.exe")
-endif()
-
-target_link_libraries(search_cli_tests PRIVATE search_core GTest::gtest_main)
-target_precompile_headers(search_cli_tests PRIVATE include/rockyou/pch.h)
-target_compile_definitions(search_cli_tests PRIVATE
-  TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/tests/data"
-  SEARCH_BINARY_PATH="${SEARCH_BINARY_PATH_VALUE}"
-)
-
-add_test(NAME search_cli_tests COMMAND search_cli_tests)
 
 include(InstallRequiredSystemLibraries)
 set(CPACK_PACKAGE_VENDOR "Volker Schwaberow")

--- a/include/rockyou/pch.h
+++ b/include/rockyou/pch.h
@@ -37,7 +37,7 @@
 namespace rockyou {
 
 inline constexpr std::string_view kProjectName = "rockyou2024";
-inline constexpr std::string_view kProjectVersion = "0.3.0";
+inline constexpr std::string_view kProjectVersion = "0.3.1";
 inline constexpr std::string_view kProjectAuthor = "Volker Schwaberow <volker@schwaberow.de>";
 inline constexpr std::string_view kProjectLicense = "MIT";
 


### PR DESCRIPTION
- Replacing the "hard" requirement ofr a manual vendor checkout
- Bump cmake_minimum_required to 3.18
- Cleanup the non-committed tests