### PR TITLE
New stuff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ target_sources(search_core
       src/rockyou.search_engine.cppm
       src/rockyou.terminal_ui.cppm
       src/rockyou.zip_reader.cppm
+      src/rockyou.regex_engine.cppm
   PRIVATE
     src/search_engine.cc
     src/terminal_ui.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.30)
 
-project(rockyou2024 VERSION 0.4.0 LANGUAGES C CXX)
+project(rockyou2024 VERSION 0.6.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rockyou2024
 
-rockyou2024 is a command-line tool (native modules) that searches the rockyou2024 wordlist directly inside the ZIP archive — no unpacking required.
+rockyou2024 is a command-line tool (native C++26 modules) that searches the rockyou2024 wordlist directly inside the ZIP archive — no unpacking required. Features both literal keyword search and powerful regex pattern matching for security research and password policy analysis.
 
 ## Quick start
 
@@ -9,18 +9,18 @@ Prebuilt archives ship with each GitHub release. Download the one that matches y
 ### Linux / macOS
 
 ```bash
-download_url=https://github.com/vschwaberow/rockyou2024/releases/download/v0.3.0/search-linux-v0.3.0.zip
+download_url=https://github.com/vschwaberow/rockyou2024/releases/download/v0.6.0/search-linux-v0.6.0.zip
 curl -LO "$download_url"
-unzip search-linux-v0.3.0.zip -d rockyou2024-linux
+unzip search-linux-v0.6.0.zip -d rockyou2024-linux
 ```
 
-Replace the URL with the macOS package when needed (`https://github.com/vschwaberow/rockyou2024/releases/download/v0.3.0/search-macos-v0.3.0.zip`).
+Replace the URL with the macOS package when needed (`https://github.com/vschwaberow/rockyou2024/releases/download/v0.6.0/search-macos-v0.6.0.zip`).
 
 ### Windows
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/vschwaberow/rockyou2024/releases/download/v0.3.0/search-windows-v0.3.0.zip -OutFile search-windows-v0.3.0.zip
-Expand-Archive -Path search-windows-v0.3.0.zip -DestinationPath rockyou2024-windows
+Invoke-WebRequest -Uri https://github.com/vschwaberow/rockyou2024/releases/download/v0.6.0/search-windows-v0.6.0.zip -OutFile search-windows-v0.6.0.zip
+Expand-Archive -Path search-windows-v0.6.0.zip -DestinationPath rockyou2024-windows
 ```
 
 ## Usage
@@ -28,7 +28,7 @@ Expand-Archive -Path search-windows-v0.3.0.zip -DestinationPath rockyou2024-wind
 From the extracted folder:
 
 ```bash
-./search <zip_file> <keyword> [-i] [--quiet|--json] [--limit N] [--per-file-limit N] [--threads N] [--chunk BYTES] [--context CHARS] [--checksum sha256:HEX|blake3:HEX] [--highlight]
+./search <zip_file> <keyword> [-i] [--quiet|--json] [--limit N] [--per-file-limit N] [--threads N] [--chunk BYTES] [--context CHARS] [--checksum sha256:HEX|blake3:HEX] [--highlight] [--regex] [--regex-mode MODE]
 ./search --interactive
 ```
 
@@ -36,12 +36,35 @@ PowerShell is similar:
 
 ```powershell
 .
-search.exe <zip_file> <keyword> [-i] [--quiet|--json] [--limit N] [--per-file-limit N] [--threads N] [--chunk BYTES] [--context CHARS] [--checksum sha256:HEX|blake3:HEX] [--highlight]
+search.exe <zip_file> <keyword> [-i] [--quiet|--json] [--limit N] [--per-file-limit N] [--threads N] [--chunk BYTES] [--context CHARS] [--checksum sha256:HEX|blake3:HEX] [--highlight] [--regex] [--regex-mode MODE]
 .
 search.exe --interactive
 ```
 
 The tool exits with `0` on success. On errors you’ll get a short status message explaining what went wrong.
+
+## Regex Pattern Search
+
+Enable regex mode with `--regex` to search for patterns instead of literal keywords:
+
+```bash
+# Find email patterns
+./search rockyou2024.zip --regex ‘[a-z]+@[a-z]+\.[a-z]+’
+
+# Find passwords with policy violations (e.g., ends with 3+ digits)
+./search rockyou2024.zip --regex ‘^[A-Za-z].*[0-9]{3}$’
+
+# Case-insensitive regex with JSON output
+./search rockyou2024.zip --regex -i --json ‘pass.*[0-9]+’
+
+# Use different regex engines
+./search rockyou2024.zip --regex --regex-mode grep ‘http://www\.’
+
+# Complex pattern with alternation
+./search rockyou2024.zip --regex ‘(admin|root|password).*[0-9]’
+```
+
+Supported regex modes: `ecmascript` (default), `awk`, `grep`, `egrep`
 
 ## Build it yourself
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -97,8 +97,11 @@ int main(int argc, char* argv[]) {
         options.json = true;
       } else if (arg == rockyou::kHighlightFlag) {
         options.highlight = true;
+      } else if (arg == rockyou::kRegexFlag) {
+        options.regex = true;
       } else if (arg == rockyou::kLimitFlag || arg == rockyou::kPerFileLimitFlag || arg == rockyou::kThreadsFlag ||
-                 arg == rockyou::kChunkSizeFlag || arg == rockyou::kContextSizeFlag || arg == rockyou::kChecksumFlag) {
+                 arg == rockyou::kChunkSizeFlag || arg == rockyou::kContextSizeFlag || arg == rockyou::kChecksumFlag ||
+                 arg == rockyou::kRegexModeFlag) {
         if (i + 1 >= argc) {
           rockyou::PrintUsage(argv[0]);
           return 1;
@@ -141,6 +144,8 @@ int main(int argc, char* argv[]) {
           options.context_size = parsed;
         } else if (arg == rockyou::kChecksumFlag) {
           options.checksum = std::string(value);
+        } else if (arg == rockyou::kRegexModeFlag) {
+          options.regex_mode = std::string(value);
         }
         ++i;
       } else if (arg == "--help") {

--- a/src/rockyou.messages.cppm
+++ b/src/rockyou.messages.cppm
@@ -90,6 +90,20 @@ inline constexpr std::string_view kInteractiveHelp =
 inline constexpr std::string_view kInteractivePromptAction = "Action (s=search, q=quit): ";
 inline constexpr std::string_view kInteractiveExit = "Exiting interactive mode.";
 
+inline constexpr std::string_view kRegexFlag = "--regex";
+inline constexpr std::string_view kRegexModeFlag = "--regex-mode";
+inline constexpr std::string_view kUsageRegexOption =
+    "  --regex          Enable regex pattern matching instead of literal keyword";
+inline constexpr std::string_view kUsageRegexModeOption =
+    "  --regex-mode MODE Set regex mode: ecmascript|awk|grep|egrep (default: ecmascript)";
+inline constexpr std::string_view kErrorEmptyRegexPattern = "Regex pattern must not be empty";
+inline constexpr std::string_view kErrorInvalidRegexPattern = "Invalid regex pattern '{}': {}";
+inline constexpr std::string_view kRegexPatternFormat = "Regex pattern: {} ({})";
+inline constexpr std::string_view kPromptUseRegex = "Use regex pattern matching? (y/n): ";
+inline constexpr std::string_view kPromptEnterRegexPattern = "Enter the regex pattern to search: ";
+inline constexpr std::string_view kPromptEnterRegexMode =
+    "Enter regex mode (ecmascript/awk/grep/egrep, or leave blank for default): ";
+
 inline constexpr std::string_view kProjectName = "rockyou2024";
 inline constexpr std::string_view kProjectVersion = "0.6.0";
 inline constexpr std::string_view kProjectAuthor = "Volker Schwaberow <volker@schwaberow.de>";

--- a/src/rockyou.messages.cppm
+++ b/src/rockyou.messages.cppm
@@ -91,7 +91,7 @@ inline constexpr std::string_view kInteractivePromptAction = "Action (s=search, 
 inline constexpr std::string_view kInteractiveExit = "Exiting interactive mode.";
 
 inline constexpr std::string_view kProjectName = "rockyou2024";
-inline constexpr std::string_view kProjectVersion = "0.5.0";
+inline constexpr std::string_view kProjectVersion = "0.6.0";
 inline constexpr std::string_view kProjectAuthor = "Volker Schwaberow <volker@schwaberow.de>";
 inline constexpr std::string_view kProjectLicense = "MIT";
 

--- a/src/rockyou.regex_engine.cppm
+++ b/src/rockyou.regex_engine.cppm
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+// (c) 2024-2026 Volker Schwaberow <volker@schwaberow.de>
+
+module;
+
+#include <print>
+#include <algorithm>
+#include <expected>
+#include <format>
+#include <regex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+export module rockyou.regex_engine;
+
+import rockyou.error_handling;
+import rockyou.messages;
+
+export namespace rockyou {
+
+enum class RegexMode : int { kECMAScript = 0, kAwk = 1, kGrep = 2, kEgrep = 3 };
+
+struct RegexPattern {
+  std::regex pattern;
+  RegexMode mode;
+  std::string source;
+  size_t min_match_length;
+  std::string literal_prefix;
+
+  bool HasLiteralPrefix() const { return !literal_prefix.empty() && literal_prefix.length() >= 3; }
+};
+
+struct RegexMatch {
+  size_t position;
+  size_t length;
+  std::string matched_text;
+};
+
+Result<RegexPattern> CompileRegexPattern(const std::string& pattern_str, RegexMode mode = RegexMode::kECMAScript);
+
+std::vector<RegexMatch> RegexSearchAll(const RegexPattern& regex_pattern, std::string_view text);
+
+bool RegexSearchAny(const RegexPattern& regex_pattern, std::string_view text);
+
+std::string GetLiteralPrefixForFastPath(const RegexPattern& pattern);
+
+RegexMode ParseRegexMode(std::string_view mode_str);
+
+std::string_view RegexModeToString(RegexMode mode);
+
+} // namespace rockyou
+
+namespace {
+
+std::string ExtractLiteralPrefix(std::string_view pattern) {
+  std::string prefix;
+  bool escape_next = false;
+  bool in_char_class = false;
+
+  for (size_t i = 0; i < pattern.length() && prefix.length() < 32; ++i) {
+    char c = pattern[i];
+
+    if (escape_next) {
+      prefix += c;
+      escape_next = false;
+      continue;
+    }
+
+    if (c == '\\') {
+      escape_next = true;
+      continue;
+    }
+
+    if (c == '[' && !in_char_class) {
+      in_char_class = true;
+      continue;
+    }
+
+    if (c == ']' && in_char_class) {
+      in_char_class = false;
+      continue;
+    }
+
+    if (in_char_class) {
+      continue;
+    }
+
+    if (c == '^' || c == '$' || c == '.' || c == '*' || c == '+' || c == '?' || c == '|' || c == '(' || c == ')' ||
+        c == '{' || c == '}') {
+      break;
+    }
+
+    prefix += c;
+  }
+
+  return prefix;
+}
+
+std::regex::flag_type ConvertRegexMode(rockyou::RegexMode mode) {
+  switch (mode) {
+    case rockyou::RegexMode::kECMAScript:
+      return std::regex::ECMAScript;
+    case rockyou::RegexMode::kAwk:
+      return std::regex::awk;
+    case rockyou::RegexMode::kGrep:
+      return std::regex::grep;
+    case rockyou::RegexMode::kEgrep:
+      return std::regex::egrep;
+    default:
+      return std::regex::ECMAScript;
+  }
+}
+
+std::size_t EstimateMinMatchLength(std::string_view pattern) {
+  std::size_t min_len = 0;
+  bool escape_next = false;
+  bool in_char_class = false;
+
+  for (size_t i = 0; i < pattern.length(); ++i) {
+    char c = pattern[i];
+
+    if (escape_next) {
+      min_len++;
+      escape_next = false;
+      continue;
+    }
+
+    if (c == '\\') {
+      escape_next = true;
+      continue;
+    }
+
+    if (c == '[' && !in_char_class) {
+      in_char_class = true;
+      continue;
+    }
+
+    if (c == ']' && in_char_class) {
+      in_char_class = false;
+      min_len++;
+      continue;
+    }
+
+    if (in_char_class) {
+      continue;
+    }
+
+    switch (c) {
+      case '^':
+      case '$':
+      case '|':
+      case '(':
+      case ')':
+        break;
+      case '.':
+      case '*':
+      case '+':
+      case '?':
+      case '{':
+      case '}':
+        break;
+      default:
+        min_len++;
+    }
+  }
+
+  return min_len;
+}
+
+} // anonymous namespace
+
+namespace rockyou {
+
+Result<RegexPattern> CompileRegexPattern(const std::string& pattern_str, RegexMode mode) {
+
+  if (pattern_str.empty()) {
+    return std::unexpected(MakeError(ErrorCode::InvalidInput, std::string(kErrorEmptyRegexPattern)));
+  }
+
+  try {
+    auto regex_flags = ConvertRegexMode(mode);
+    std::regex compiled_pattern(pattern_str, regex_flags);
+
+    auto literal_prefix = ExtractLiteralPrefix(pattern_str);
+    auto min_match_length = EstimateMinMatchLength(pattern_str);
+
+    return RegexPattern{.pattern = std::move(compiled_pattern),
+                        .mode = mode,
+                        .source = pattern_str,
+                        .min_match_length = min_match_length,
+                        .literal_prefix = std::move(literal_prefix)};
+  } catch (const std::regex_error& e) {
+    return std::unexpected(
+        MakeError(ErrorCode::InvalidInput, std::format(kErrorInvalidRegexPattern, pattern_str, e.what())));
+  }
+}
+
+std::vector<RegexMatch> RegexSearchAll(const RegexPattern& regex_pattern, std::string_view text) {
+
+  std::vector<RegexMatch> matches;
+  std::string str(text);
+  std::smatch match_results;
+
+  auto begin = str.cbegin();
+  auto end = str.cend();
+
+  while (std::regex_search(begin, end, match_results, regex_pattern.pattern)) {
+    if (match_results.empty()) {
+      break;
+    }
+
+    size_t position = std::distance(str.cbegin(), match_results[0].first);
+    size_t length = match_results[0].length();
+
+    matches.push_back(RegexMatch{.position = position, .length = length, .matched_text = match_results.str(0)});
+
+    begin = match_results[0].second;
+  }
+
+  return matches;
+}
+
+bool RegexSearchAny(const RegexPattern& regex_pattern, std::string_view text) {
+
+  std::string str(text);
+  return std::regex_search(str, regex_pattern.pattern);
+}
+
+std::string GetLiteralPrefixForFastPath(const RegexPattern& pattern) {
+  if (!pattern.HasLiteralPrefix()) {
+    return "";
+  }
+
+  if (pattern.literal_prefix.length() < 3) {
+    return "";
+  }
+
+  return pattern.literal_prefix;
+}
+
+RegexMode ParseRegexMode(std::string_view mode_str) {
+  if (mode_str == "ecmascript" || mode_str == "ECMAScript" || mode_str.empty()) {
+    return RegexMode::kECMAScript;
+  } else if (mode_str == "awk" || mode_str == "AWK") {
+    return RegexMode::kAwk;
+  } else if (mode_str == "grep" || mode_str == "GREP") {
+    return RegexMode::kGrep;
+  } else if (mode_str == "egrep" || mode_str == "EGREP") {
+    return RegexMode::kEgrep;
+  }
+  return RegexMode::kECMAScript;
+}
+
+std::string_view RegexModeToString(RegexMode mode) {
+  switch (mode) {
+    case RegexMode::kECMAScript:
+      return "ECMAScript";
+    case RegexMode::kAwk:
+      return "awk";
+    case RegexMode::kGrep:
+      return "grep";
+    case RegexMode::kEgrep:
+      return "egrep";
+    default:
+      return "ECMAScript";
+  }
+}
+
+} // namespace rockyou

--- a/src/rockyou.search_engine.cppm
+++ b/src/rockyou.search_engine.cppm
@@ -37,12 +37,14 @@ struct SearchOptions {
   bool quiet = false;
   bool json = false;
   bool highlight = false;
+  bool regex = false;
   std::optional<int> limit;
   std::optional<int> per_file_limit;
   std::optional<unsigned int> thread_count;
   std::optional<size_t> chunk_size;
   std::optional<size_t> context_size;
   std::optional<std::string> checksum;
+  std::optional<std::string> regex_mode;
 };
 
 Result<void> SearchZip(const std::string& path, const std::string& keyword, const SearchOptions& options);

--- a/src/search_engine.cc
+++ b/src/search_engine.cc
@@ -41,6 +41,7 @@ module rockyou.search_engine;
 import rockyou.messages;
 import rockyou.error_handling;
 import rockyou.zip_reader;
+import rockyou.regex_engine;
 
 // Modern C++26 error handling from the module
 using rockyou::AppError;
@@ -107,6 +108,53 @@ std::vector<size_t> SearchPositions(std::string_view text, std::string_view patt
   std::string lowered(text);
   LowerInPlace(&lowered);
   return BoyerMoore(lowered, pattern);
+}
+
+std::vector<size_t> SearchPositionsRegex(std::string_view text, const RegexPattern& regex_pattern) {
+  std::vector<size_t> positions;
+  auto matches = RegexSearchAll(regex_pattern, text);
+  positions.reserve(matches.size());
+  for (const auto& match : matches) {
+    positions.push_back(match.position);
+  }
+  return positions;
+}
+
+std::vector<size_t> SearchPositionsHybrid(std::string_view text, const RegexPattern& regex_pattern) {
+  std::string literal_prefix = GetLiteralPrefixForFastPath(regex_pattern);
+  if (literal_prefix.empty() || literal_prefix.length() < 3) {
+    return SearchPositionsRegex(text, regex_pattern);
+  }
+
+  std::vector<size_t> candidates;
+  {
+    std::string lowered(text);
+    LowerInPlace(&lowered);
+    std::string prefix_lower = literal_prefix;
+    LowerInPlace(&prefix_lower);
+    candidates = BoyerMoore(lowered, prefix_lower);
+  }
+
+  std::vector<size_t> verified_positions;
+  verified_positions.reserve(candidates.size());
+
+  for (size_t candidate_pos : candidates) {
+    size_t scan_start = candidate_pos > 100 ? candidate_pos - 100 : 0;
+    size_t scan_end = std::min(candidate_pos + 200, text.length());
+    std::string_view scan_window = text.substr(scan_start, scan_end - scan_start);
+
+    auto matches = RegexSearchAll(regex_pattern, scan_window);
+    for (const auto& match : matches) {
+      size_t absolute_pos = scan_start + match.position;
+      if (absolute_pos >= candidate_pos - 50 && absolute_pos < candidate_pos + 150) {
+        verified_positions.push_back(absolute_pos);
+      }
+    }
+  }
+
+  std::sort(verified_positions.begin(), verified_positions.end());
+  verified_positions.erase(std::unique(verified_positions.begin(), verified_positions.end()), verified_positions.end());
+  return verified_positions;
 }
 
 void AppendNewlines(std::string_view chunk, size_t base_offset, std::vector<size_t>* newline_offsets) {
@@ -228,6 +276,16 @@ std::string BuildJson(const std::vector<SearchResult>& results, int total_occurr
     json.append(std::to_string(options.context_size.value()));
   } else {
     json.append("null");
+  }
+  json.append(",\"regex\":");
+  json.append(options.regex ? "true" : "false");
+  json.append(",\"regex_mode\":");
+  if (options.regex_mode.has_value()) {
+    json.append("\"");
+    json.append(EscapeJson(options.regex_mode.value()));
+    json.append("\"");
+  } else {
+    json.append("\"\"");
   }
   json.append("},\"results\":[");
   for (size_t i = 0; i < results.size(); ++i) {
@@ -506,6 +564,108 @@ SearchFile(const std::string& path, const std::string& name, const ZipIndexEntry
   return result;
 }
 
+std::expected<SearchResult, rockyou::AppError> SearchFileRegex(const std::string& path, const std::string& name,
+                                                               const ZipIndexEntry& entry,
+                                                               const RegexPattern& regex_pattern, size_t chunk_size,
+                                                               size_t context_size, size_t min_buffer_size,
+                                                               std::optional<int> per_file_limit, bool highlight) {
+  auto stream_or = ZipEntryStream::Create(path, name, entry);
+  if (!stream_or) {
+    return std::unexpected(stream_or.error());
+  }
+  ZipEntryStream stream = *std::move(stream_or);
+  SearchResult result;
+  result.filename = name;
+
+  if (entry.size >= min_buffer_size) {
+    std::string buffer(entry.size, '\0');
+    size_t total = 0;
+    while (total < buffer.size()) {
+      const size_t remaining = buffer.size() - total;
+      auto read_or = stream.Read(buffer.data() + total, static_cast<unsigned int>(remaining));
+      if (!read_or) {
+        return std::unexpected(read_or.error());
+      }
+      const int read_bytes = *read_or;
+      if (read_bytes == 0) {
+        break;
+      }
+      total += static_cast<size_t>(read_bytes);
+    }
+    buffer.resize(total);
+    std::vector<size_t> newline_offsets;
+    AppendNewlines(buffer, 0, &newline_offsets);
+
+    const auto matches = RegexSearchAll(regex_pattern, buffer);
+    for (const auto& match : matches) {
+      const auto line_column = ComputeLineColumn(newline_offsets, match.position);
+      const std::string context =
+          BuildHighlightedContext(buffer, match.position, match.length, context_size, highlight);
+      result.occurrences.emplace_back(line_column.first, line_column.second, context);
+      if (per_file_limit.has_value() && static_cast<int>(result.occurrences.size()) >= per_file_limit.value()) {
+        result.truncated = true;
+        break;
+      }
+    }
+    return result;
+  }
+
+  std::vector<size_t> newline_offsets;
+  std::vector<char> buffer(chunk_size);
+  std::string overlap;
+  size_t processed = 0;
+
+  while (true) {
+    auto read_or = stream.Read(buffer.data(), static_cast<unsigned int>(buffer.size()));
+    if (!read_or) {
+      return std::unexpected(read_or.error());
+    }
+    const int read_bytes = read_or.value();
+    if (read_bytes == 0) {
+      break;
+    }
+
+    std::string chunk(buffer.data(), static_cast<size_t>(read_bytes));
+    AppendNewlines(chunk, processed, &newline_offsets);
+
+    const size_t prefix_length = overlap.size();
+    const size_t base = processed >= prefix_length ? processed - prefix_length : 0;
+    std::string search_text = overlap + chunk;
+
+    const auto matches = RegexSearchAll(regex_pattern, search_text);
+    const size_t threshold = processed >= prefix_length ? processed - prefix_length : 0;
+
+    for (const auto& match : matches) {
+      const size_t absolute = base + match.position;
+      if (absolute < threshold) {
+        continue;
+      }
+      const auto line_column = ComputeLineColumn(newline_offsets, absolute);
+      const std::string context =
+          BuildHighlightedContext(search_text, match.position, match.length, context_size, highlight);
+      result.occurrences.emplace_back(line_column.first, line_column.second, context);
+      if (per_file_limit.has_value() && static_cast<int>(result.occurrences.size()) >= per_file_limit.value()) {
+        result.truncated = true;
+        break;
+      }
+    }
+
+    processed += static_cast<size_t>(read_bytes);
+    const size_t max_overlap = regex_pattern.min_match_length > 0 ? regex_pattern.min_match_length - 1 : 0;
+    if (search_text.size() <= max_overlap) {
+      overlap = search_text;
+    } else {
+      overlap = search_text.substr(search_text.size() - max_overlap);
+    }
+  }
+
+  auto close_status = stream.CloseWithStatus();
+  if (!close_status) {
+    return std::unexpected(close_status.error());
+  }
+  return result;
+}
+
 } // namespace
 
 Result<void> SearchZip(const std::string& path, const std::string& keyword, const SearchOptions& options) {
@@ -530,6 +690,20 @@ Result<void> SearchZip(const std::string& path, const std::string& keyword, cons
   const size_t chunk_size = options.chunk_size.value_or(kDefaultChunkSize);
   const size_t min_buffer_size = kDefaultMinFileSizeForBuffer;
   const size_t context_size = options.context_size.value_or(static_cast<size_t>(kDefaultContextSize));
+
+  std::optional<RegexPattern> regex_pattern;
+  if (options.regex) {
+    RegexMode mode = RegexMode::kECMAScript;
+    if (options.regex_mode.has_value()) {
+      mode = ParseRegexMode(options.regex_mode.value());
+    }
+    auto compiled_or = CompileRegexPattern(keyword, mode);
+    if (!compiled_or) {
+      return std::unexpected(compiled_or.error());
+    }
+    regex_pattern = *std::move(compiled_or);
+  }
+
   auto checksum_status = ValidateChecksum(path, options.checksum);
   if (!checksum_status) {
     return std::unexpected(checksum_status.error());
@@ -553,7 +727,7 @@ Result<void> SearchZip(const std::string& path, const std::string& keyword, cons
   std::atomic<size_t> next_index{0};
   std::atomic<int> remaining_limit{options.limit.has_value() ? options.limit.value() : std::numeric_limits<int>::max()};
   std::string pattern_storage = keyword;
-  if (options.case_insensitive) {
+  if (options.case_insensitive && !options.regex) {
     LowerInPlace(&pattern_storage);
   }
   const std::string_view pattern = pattern_storage;
@@ -592,9 +766,15 @@ Result<void> SearchZip(const std::string& path, const std::string& keyword, cons
             continue;
           }
           const auto& entry = entries[idx];
-          auto result_or =
-              SearchFile(path, entry.first, entry.second, keyword, pattern, options.case_insensitive, chunk_size,
-                         context_size, min_buffer_size, options.per_file_limit, options.highlight);
+          std::expected<SearchResult, rockyou::AppError> result_or;
+          if (regex_pattern.has_value()) {
+            result_or = SearchFileRegex(path, entry.first, entry.second, regex_pattern.value(), chunk_size,
+                                        context_size, min_buffer_size, options.per_file_limit, options.highlight);
+          } else {
+            result_or =
+                SearchFile(path, entry.first, entry.second, keyword, pattern, options.case_insensitive, chunk_size,
+                           context_size, min_buffer_size, options.per_file_limit, options.highlight);
+          }
           if (!result_or) {
             errors[idx] = std::format(kErrorProcessingFormat, entry.first, result_or.error().message);
             SearchResult failed;

--- a/src/terminal_ui.cc
+++ b/src/terminal_ui.cc
@@ -46,6 +46,8 @@ void PrintUsage(const std::string& program_name) {
   std::println(kUsageContextOption);
   std::println(kUsageChecksumOption);
   std::println(kUsageHighlightOption);
+  std::println(kUsageRegexOption);
+  std::println(kUsageRegexModeOption);
   std::println(kUsageHelpOption);
 }
 

--- a/tests/search_engine_test.cc
+++ b/tests/search_engine_test.cc
@@ -13,6 +13,7 @@ import rockyou.search_engine;
 import rockyou.error_handling;
 import rockyou.zip_reader;
 import rockyou.messages;
+import rockyou.regex_engine;
 
 namespace rockyou {}
 
@@ -413,6 +414,186 @@ TEST(SearchEngineTest, CLILongKeywordDoesNotCrash) {
   std::string cmd = bin + " " + zip + " " + long_kw + " > /tmp/rockyou_cli_long.txt 2>&1";
   int ret = std::system(cmd.c_str());
   EXPECT_GE(ret, 0);
+}
+
+// Regex Pattern Search Tests
+TEST(RegexEngineTest, RegexSearchFindsBasicPattern) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "password123", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("Occurrences in \"common.txt\": 1"), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchWithWildcardPattern) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "pass.*123", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("Occurrences in \"common.txt\": 1"), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchWithCharacterClass) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "[Bb]eta.*[0-9]", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("Occurrences in \"common.txt\": 1"), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchFindsMultipleMatchesWithAlternation) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "(alpha|epsilon)", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("Occurrences in \"common.txt\": 1"), std::string::npos);
+  EXPECT_NE(output.find("Occurrences in \"nested/other.txt\": 1"), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchWithQuantifiers) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "p.*d", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("Occurrences in \"common.txt\": 1"), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchAnchoredPattern) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "^alpha", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("Occurrences in \"common.txt\": 1"), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchRejectsEmptyPattern) {
+  rockyou::SearchOptions options;
+  options.regex = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "", options);
+  EXPECT_FALSE(status.has_value());
+  if (!status) {
+    EXPECT_EQ(status.error().code, rockyou::ErrorCode::InvalidInput);
+  }
+}
+
+TEST(RegexEngineTest, RegexSearchRejectsInvalidPattern) {
+  rockyou::SearchOptions options;
+  options.regex = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "[unclosed", options);
+  EXPECT_FALSE(status.has_value());
+  if (!status) {
+    EXPECT_EQ(status.error().code, rockyou::ErrorCode::InvalidInput);
+  }
+}
+
+TEST(RegexEngineTest, RegexSearchWithJsonOutput) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  options.json = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "pass.*123", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("\"total\""), std::string::npos);
+  EXPECT_NE(output.find("\"regex\":true"), std::string::npos);
+  EXPECT_NE(output.find("\"regex_mode\":\"\""), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchWithQuietMode) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  options.quiet = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "alpha", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_EQ(output.find("Occurrences"), std::string::npos);
+  EXPECT_NE(output.find("common.txt"), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchWithLimit) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  options.limit = 1;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "(alpha|Beta|gamma|delta|epsilon)", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("truncated"), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchECMAScriptMode) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  options.regex_mode = "ecmascript";
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "[A-Z][a-z]+", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("Occurrences in \"common.txt\""), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchGrepMode) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  options.regex_mode = "grep";
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "pass", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("Occurrences in \"common.txt\": 1"), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchWithSpecialCharacters) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "\\w+\\d+", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("Occurrences in \"common.txt\": 1"), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchWithRepetition) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "s{2}", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("Occurrences in \"common.txt\": 1"), std::string::npos);
+}
+
+TEST(RegexEngineTest, RegexSearchEmailPattern) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "[a-z]+@[a-z]+\\.[a-z]+", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+}
+
+TEST(RegexEngineTest, RegexSearchWithPerFileLimit) {
+  testing::internal::CaptureStdout();
+  rockyou::SearchOptions options;
+  options.regex = true;
+  options.per_file_limit = 1;
+  auto status = rockyou::SearchZip(TestDataPath("sample.zip").string(), "[a-z]+", options);
+  const std::string output = testing::internal::GetCapturedStdout();
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_NE(output.find("truncated"), std::string::npos);
 }
 
 } // namespace


### PR DESCRIPTION
This pull request introduces regex pattern matching to the `rockyou2024` search engine, allowing users to search zip
  archives using powerful regular expressions instead of simple literal keywords. The update includes a new regex engine
  integration, full CLI support, and bumps the project version to `0.6.0`.
  
   * **CLI & Options parsing:**
      * Added `--regex` flag to enable regex search logic.
      * Added `--regex-mode MODE` to let users choose the regex syntax flavor (defaults to `ecmascript`, with support for
  `awk`, `grep`, and `egrep`).
    * **Search Engine Integration:**
      * Implemented `SearchFileRegex` alongside hybrid search fallbacks (`SearchPositionsRegex` and `SearchPositionsHybrid`)
  to optimize matching efficiency.
      * Extended the JSON output structure to report `"regex": true` and the chosen `"regex_mode"`.
   * **Project Version Bump:**
      * Bumped the version from `0.5.0` to `0.6.0` in both `CMakeLists.txt` and `src/rockyou.messages.cppm` to reflect the new
  capabilities.